### PR TITLE
Update for system requirements and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,30 @@ Development Buildout of OpenProcurement
 Follow the instructions:
 
   1. Bootstrap the buildout with Python 2.7:
-  
+
      ```
      $ python bootstrap.py
      ```
-     
+
   2. Build the buildout:
-  
+
       ```
       $ bin/buildout -N
       ```
+
+System requirements (fedora 22):
+
+    dnf install gcc file git libevent-devel python-devel sqlite-devel zeromq-devel libffi-devel openssl-devel systemd-python
+
+Local development environment also requires additional dependencies:
+
+    dnf install couchdb
+
+To start environment services:
+
+    bin/circusd --daemon
+
+To to run openprocurement.api instance:
+
+    bin/pserve etc/openprocurement.api.ini
+


### PR DESCRIPTION
I've spent some time to figure out what do I need to install in my system to be able to build and run  openprocurement.api instance. So I'm putting it in readme file.  It is a precise list of packages that I was required to install to be able to assemble the environment on clean fedora 22 without any preinstalled environment groups
