### PR TITLE
add pyramid in eggs (missing bin/pserve)

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -18,6 +18,7 @@ parts =
     openprocurement.concord
 eggs =
     chaussette
+    pyramid
     request_id_middleware
     server_cookie_middleware
     ${:package-name}


### PR DESCRIPTION
При збірці bin/buildout не з'являється bin/pserve (при чистій установці).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.buildout/7)
<!-- Reviewable:end -->
