### PR TITLE
Add `migrate` script generation

### DIFF
--- a/profiles/base.cfg
+++ b/profiles/base.cfg
@@ -62,6 +62,7 @@ scripts =
     chaussette
     contracting_data_bridge
     ceasefire_loki_caravan
+    migrate
 
 [circus]
 recipe = zc.recipe.egg


### PR DESCRIPTION
To exploit the `migrate` endpoint of the `op.api` and generate console
script, based on that endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.buildout/106)
<!-- Reviewable:end -->
